### PR TITLE
Fix errors detected by linters

### DIFF
--- a/activity.go
+++ b/activity.go
@@ -539,7 +539,7 @@ func AcceptNew(id ID, ob Item) *Accept {
 }
 
 // AddNew initializes an Add activity
-func AddNew(id ID, ob Item, trgt Item) *Add {
+func AddNew(id ID, ob, trgt Item) *Add {
 	a := ActivityNew(id, AddType, ob)
 	o := Add(*a)
 	o.Target = trgt
@@ -666,7 +666,7 @@ func ReadNew(id ID, ob Item) *Read {
 }
 
 // RemoveNew initializes a Remove activity
-func RemoveNew(id ID, ob Item, trgt Item) *Remove {
+func RemoveNew(id ID, ob, trgt Item) *Remove {
 	a := ActivityNew(id, RemoveType, ob)
 	o := Remove(*a)
 	o.Target = trgt
@@ -829,7 +829,7 @@ func mapActivityProperties(mm map[string][]byte, a *Activity) (hasData bool, err
 
 // GobEncode
 func (a Activity) GobEncode() ([]byte, error) {
-	var mm = make(map[string][]byte)
+	mm := make(map[string][]byte)
 	hasData, err := mapActivityProperties(mm, &a)
 	if err != nil {
 		return nil, err

--- a/activity.go
+++ b/activity.go
@@ -46,7 +46,7 @@ const (
 
 func (a ActivityVocabularyTypes) Contains(typ ActivityVocabularyType) bool {
 	for _, v := range a {
-		if strings.ToLower(string(v)) == strings.ToLower(string(typ)) {
+		if strings.EqualFold(string(v), string(typ)) {
 			return true
 		}
 	}

--- a/activity_test.go
+++ b/activity_test.go
@@ -8,7 +8,7 @@ import (
 )
 
 func TestActivityNew(t *testing.T) {
-	var testValue = ID("test")
+	testValue := ID("test")
 	var testType ActivityVocabularyType = "Accept"
 
 	a := ActivityNew(testValue, testType, nil)
@@ -30,7 +30,7 @@ func TestActivityNew(t *testing.T) {
 }
 
 func TestAcceptNew(t *testing.T) {
-	var testValue = ID("test")
+	testValue := ID("test")
 
 	a := AcceptNew(testValue, nil)
 
@@ -43,7 +43,7 @@ func TestAcceptNew(t *testing.T) {
 }
 
 func TestAddNew(t *testing.T) {
-	var testValue = ID("test")
+	testValue := ID("test")
 
 	a := AddNew(testValue, nil, nil)
 
@@ -56,7 +56,7 @@ func TestAddNew(t *testing.T) {
 }
 
 func TestAnnounceNew(t *testing.T) {
-	var testValue = ID("test")
+	testValue := ID("test")
 
 	a := AnnounceNew(testValue, nil)
 
@@ -69,7 +69,7 @@ func TestAnnounceNew(t *testing.T) {
 }
 
 func TestBlockNew(t *testing.T) {
-	var testValue = ID("test")
+	testValue := ID("test")
 
 	a := BlockNew(testValue, nil)
 
@@ -82,7 +82,7 @@ func TestBlockNew(t *testing.T) {
 }
 
 func TestCreateNew(t *testing.T) {
-	var testValue = ID("test")
+	testValue := ID("test")
 
 	a := CreateNew(testValue, nil)
 
@@ -95,7 +95,7 @@ func TestCreateNew(t *testing.T) {
 }
 
 func TestDeleteNew(t *testing.T) {
-	var testValue = ID("test")
+	testValue := ID("test")
 
 	a := DeleteNew(testValue, nil)
 
@@ -108,7 +108,7 @@ func TestDeleteNew(t *testing.T) {
 }
 
 func TestDislikeNew(t *testing.T) {
-	var testValue = ID("test")
+	testValue := ID("test")
 
 	a := DislikeNew(testValue, nil)
 
@@ -121,7 +121,7 @@ func TestDislikeNew(t *testing.T) {
 }
 
 func TestFlagNew(t *testing.T) {
-	var testValue = ID("test")
+	testValue := ID("test")
 
 	a := FlagNew(testValue, nil)
 
@@ -134,7 +134,7 @@ func TestFlagNew(t *testing.T) {
 }
 
 func TestFollowNew(t *testing.T) {
-	var testValue = ID("test")
+	testValue := ID("test")
 
 	a := FollowNew(testValue, nil)
 
@@ -147,7 +147,7 @@ func TestFollowNew(t *testing.T) {
 }
 
 func TestIgnoreNew(t *testing.T) {
-	var testValue = ID("test")
+	testValue := ID("test")
 
 	a := IgnoreNew(testValue, nil)
 
@@ -160,7 +160,7 @@ func TestIgnoreNew(t *testing.T) {
 }
 
 func TestInviteNew(t *testing.T) {
-	var testValue = ID("test")
+	testValue := ID("test")
 
 	a := InviteNew(testValue, nil)
 
@@ -173,7 +173,7 @@ func TestInviteNew(t *testing.T) {
 }
 
 func TestJoinNew(t *testing.T) {
-	var testValue = ID("test")
+	testValue := ID("test")
 
 	a := JoinNew(testValue, nil)
 
@@ -186,7 +186,7 @@ func TestJoinNew(t *testing.T) {
 }
 
 func TestLeaveNew(t *testing.T) {
-	var testValue = ID("test")
+	testValue := ID("test")
 
 	a := LeaveNew(testValue, nil)
 
@@ -199,7 +199,7 @@ func TestLeaveNew(t *testing.T) {
 }
 
 func TestLikeNew(t *testing.T) {
-	var testValue = ID("test")
+	testValue := ID("test")
 
 	a := LikeNew(testValue, nil)
 
@@ -212,7 +212,7 @@ func TestLikeNew(t *testing.T) {
 }
 
 func TestListenNew(t *testing.T) {
-	var testValue = ID("test")
+	testValue := ID("test")
 
 	a := ListenNew(testValue, nil)
 
@@ -225,7 +225,7 @@ func TestListenNew(t *testing.T) {
 }
 
 func TestMoveNew(t *testing.T) {
-	var testValue = ID("test")
+	testValue := ID("test")
 
 	a := MoveNew(testValue, nil)
 
@@ -238,7 +238,7 @@ func TestMoveNew(t *testing.T) {
 }
 
 func TestOfferNew(t *testing.T) {
-	var testValue = ID("test")
+	testValue := ID("test")
 
 	a := OfferNew(testValue, nil)
 
@@ -251,7 +251,7 @@ func TestOfferNew(t *testing.T) {
 }
 
 func TestRejectNew(t *testing.T) {
-	var testValue = ID("test")
+	testValue := ID("test")
 
 	a := RejectNew(testValue, nil)
 
@@ -264,7 +264,7 @@ func TestRejectNew(t *testing.T) {
 }
 
 func TestReadNew(t *testing.T) {
-	var testValue = ID("test")
+	testValue := ID("test")
 
 	a := ReadNew(testValue, nil)
 
@@ -277,7 +277,7 @@ func TestReadNew(t *testing.T) {
 }
 
 func TestRemoveNew(t *testing.T) {
-	var testValue = ID("test")
+	testValue := ID("test")
 
 	a := RemoveNew(testValue, nil, nil)
 
@@ -290,7 +290,7 @@ func TestRemoveNew(t *testing.T) {
 }
 
 func TestTentativeRejectNew(t *testing.T) {
-	var testValue = ID("test")
+	testValue := ID("test")
 
 	a := TentativeRejectNew(testValue, nil)
 
@@ -303,7 +303,7 @@ func TestTentativeRejectNew(t *testing.T) {
 }
 
 func TestTentativeAcceptNew(t *testing.T) {
-	var testValue = ID("test")
+	testValue := ID("test")
 
 	a := TentativeAcceptNew(testValue, nil)
 
@@ -316,7 +316,7 @@ func TestTentativeAcceptNew(t *testing.T) {
 }
 
 func TestUndoNew(t *testing.T) {
-	var testValue = ID("test")
+	testValue := ID("test")
 
 	a := UndoNew(testValue, nil)
 
@@ -329,7 +329,7 @@ func TestUndoNew(t *testing.T) {
 }
 
 func TestUpdateNew(t *testing.T) {
-	var testValue = ID("test")
+	testValue := ID("test")
 
 	a := UpdateNew(testValue, nil)
 
@@ -342,7 +342,7 @@ func TestUpdateNew(t *testing.T) {
 }
 
 func TestViewNew(t *testing.T) {
-	var testValue = ID("test")
+	testValue := ID("test")
 
 	a := ViewNew(testValue, nil)
 
@@ -641,6 +641,7 @@ func TestActivity_GetID(t *testing.T) {
 		t.Errorf("%T should return an empty %T object. Received %#v", a, a.GetID(), a.GetID())
 	}
 }
+
 func TestActivity_GetIDGetType(t *testing.T) {
 	a := ActivityNew("test", ActivityType, Person{})
 
@@ -648,6 +649,7 @@ func TestActivity_GetIDGetType(t *testing.T) {
 		t.Errorf("%T should not return an empty %T object. Received %#v", a, a.GetID(), a.GetID())
 	}
 }
+
 func TestActivity_IsLink(t *testing.T) {
 	a := ActivityNew("test", ActivityType, Person{})
 
@@ -655,6 +657,7 @@ func TestActivity_IsLink(t *testing.T) {
 		t.Errorf("%T should not respond true to IsLink", a)
 	}
 }
+
 func TestActivity_IsObject(t *testing.T) {
 	a := ActivityNew("test", ActivityType, Person{})
 
@@ -956,6 +959,7 @@ func TestToActivity(t *testing.T) {
 func TestValidEventRSVPActivityType(t *testing.T) {
 	t.Skipf("TODO")
 }
+
 func TestValidGroupManagementActivityType(t *testing.T) {
 	t.Skipf("TODO")
 }

--- a/actor.go
+++ b/actor.go
@@ -247,7 +247,7 @@ func (a Actor) MarshalBinary() ([]byte, error) {
 }
 
 func (a Actor) GobEncode() ([]byte, error) {
-	var mm = make(map[string][]byte)
+	mm := make(map[string][]byte)
 	hasData, err := mapActorProperties(mm, &a)
 	if err != nil {
 		return nil, err

--- a/actor_test.go
+++ b/actor_test.go
@@ -7,8 +7,8 @@ import (
 )
 
 func TestActorNew(t *testing.T) {
-	var testValue = ID("test")
-	var testType = ApplicationType
+	testValue := ID("test")
+	testType := ApplicationType
 
 	o := ActorNew(testValue, testType)
 
@@ -29,7 +29,7 @@ func TestActorNew(t *testing.T) {
 }
 
 func TestPersonNew(t *testing.T) {
-	var testValue = ID("test")
+	testValue := ID("test")
 
 	o := PersonNew(testValue)
 	if o.ID != testValue {
@@ -41,7 +41,7 @@ func TestPersonNew(t *testing.T) {
 }
 
 func TestApplicationNew(t *testing.T) {
-	var testValue = ID("test")
+	testValue := ID("test")
 
 	o := ApplicationNew(testValue)
 	if o.ID != testValue {
@@ -53,7 +53,7 @@ func TestApplicationNew(t *testing.T) {
 }
 
 func TestGroupNew(t *testing.T) {
-	var testValue = ID("test")
+	testValue := ID("test")
 
 	o := GroupNew(testValue)
 	if o.ID != testValue {
@@ -65,7 +65,7 @@ func TestGroupNew(t *testing.T) {
 }
 
 func TestOrganizationNew(t *testing.T) {
-	var testValue = ID("test")
+	testValue := ID("test")
 
 	o := OrganizationNew(testValue)
 	if o.ID != testValue {
@@ -77,7 +77,7 @@ func TestOrganizationNew(t *testing.T) {
 }
 
 func TestServiceNew(t *testing.T) {
-	var testValue = ID("test")
+	testValue := ID("test")
 
 	o := ServiceNew(testValue)
 	if o.ID != testValue {

--- a/collection.go
+++ b/collection.go
@@ -287,7 +287,7 @@ func (c Collection) MarshalBinary() ([]byte, error) {
 }
 
 func (c Collection) GobEncode() ([]byte, error) {
-	var mm = make(map[string][]byte)
+	mm := make(map[string][]byte)
 	hasData, err := mapCollectionProperties(mm, c)
 	if err != nil {
 		return nil, err

--- a/collection_page.go
+++ b/collection_page.go
@@ -247,7 +247,7 @@ func (c CollectionPage) MarshalBinary() ([]byte, error) {
 }
 
 func (c CollectionPage) GobEncode() ([]byte, error) {
-	var mm = make(map[string][]byte)
+	mm := make(map[string][]byte)
 	hasData, err := mapCollectionPageProperties(mm, c)
 	if err != nil {
 		return nil, err

--- a/collection_page_test.go
+++ b/collection_page_test.go
@@ -7,7 +7,7 @@ import (
 )
 
 func TestCollectionPageNew(t *testing.T) {
-	var testValue = ID("test")
+	testValue := ID("test")
 
 	c := CollectionNew(testValue)
 	p := CollectionPageNew(c)

--- a/collection_test.go
+++ b/collection_test.go
@@ -7,7 +7,7 @@ import (
 )
 
 func TestCollectionNew(t *testing.T) {
-	var testValue = ID("test")
+	testValue := ID("test")
 
 	c := CollectionNew(testValue)
 

--- a/decoding_gob.go
+++ b/decoding_gob.go
@@ -345,13 +345,6 @@ func unmapObjectProperties(mm map[string][]byte, o *Object) error {
 	return nil
 }
 
-func tryDecodeObject(ob *Object, data []byte) error {
-	if err := ob.GobDecode(data); err != nil {
-		return err
-	}
-	return nil
-}
-
 func tryDecodeItems(items *ItemCollection, data []byte) error {
 	tt := make([][]byte, 0)
 	g := gob.NewDecoder(bytes.NewReader(data))

--- a/decoding_json.go
+++ b/decoding_json.go
@@ -1,10 +1,12 @@
 package activitypub
 
 import (
+	"encoding/json"
 	"fmt"
 	"net/url"
 	"strings"
 	"time"
+	"reflect"
 
 	"github.com/valyala/fastjson"
 )

--- a/decoding_json.go
+++ b/decoding_json.go
@@ -1,12 +1,13 @@
 package activitypub
 
 import (
+	"encoding"
 	"encoding/json"
 	"fmt"
 	"net/url"
+	"reflect"
 	"strings"
 	"time"
-	"reflect"
 
 	"github.com/valyala/fastjson"
 )

--- a/decoding_json.go
+++ b/decoding_json.go
@@ -1,21 +1,12 @@
 package activitypub
 
 import (
-	"encoding"
-	"encoding/json"
 	"fmt"
 	"net/url"
-	"reflect"
 	"strings"
 	"time"
 
 	"github.com/valyala/fastjson"
-)
-
-var (
-	apUnmarshalerType   = reflect.TypeOf(new(Item)).Elem()
-	unmarshalerType     = reflect.TypeOf(new(json.Unmarshaler)).Elem()
-	textUnmarshalerType = reflect.TypeOf(new(encoding.TextUnmarshaler)).Elem()
 )
 
 // ItemTyperFunc will return an instance of a struct that implements activitystreams.Item

--- a/decoding_json_test.go
+++ b/decoding_json_test.go
@@ -197,53 +197,55 @@ func deepValueEqual(t canErrorFunc, v1, v2 reflect.Value, visited map[visit]bool
 
 type testPairs map[ActivityVocabularyType]reflect.Type
 
-var objectPtrType = reflect.TypeOf(new(*Object)).Elem()
-var tombstoneType = reflect.TypeOf(new(*Tombstone)).Elem()
-var profileType = reflect.TypeOf(new(*Profile)).Elem()
-var placeType = reflect.TypeOf(new(*Place)).Elem()
-var relationshipType = reflect.TypeOf(new(*Relationship)).Elem()
-var linkPtrType = reflect.TypeOf(new(*Link)).Elem()
-var mentionPtrType = reflect.TypeOf(new(*Mention)).Elem()
-var activityPtrType = reflect.TypeOf(new(*Activity)).Elem()
-var intransitiveActivityPtrType = reflect.TypeOf(new(*IntransitiveActivity)).Elem()
-var collectionPtrType = reflect.TypeOf(new(*Collection)).Elem()
-var collectionPagePtrType = reflect.TypeOf(new(*CollectionPage)).Elem()
-var orderedCollectionPtrType = reflect.TypeOf(new(*OrderedCollection)).Elem()
-var orderedCollectionPagePtrType = reflect.TypeOf(new(*OrderedCollectionPage)).Elem()
-var actorPtrType = reflect.TypeOf(new(*Actor)).Elem()
-var applicationPtrType = reflect.TypeOf(new(*Application)).Elem()
-var servicePtrType = reflect.TypeOf(new(*Service)).Elem()
-var personPtrType = reflect.TypeOf(new(*Person)).Elem()
-var groupPtrType = reflect.TypeOf(new(*Group)).Elem()
-var organizationPtrType = reflect.TypeOf(new(*Organization)).Elem()
-var acceptPtrType = reflect.TypeOf(new(*Accept)).Elem()
-var addPtrType = reflect.TypeOf(new(*Add)).Elem()
-var announcePtrType = reflect.TypeOf(new(*Announce)).Elem()
-var arrivePtrType = reflect.TypeOf(new(*Arrive)).Elem()
-var blockPtrType = reflect.TypeOf(new(*Block)).Elem()
-var createPtrType = reflect.TypeOf(new(*Create)).Elem()
-var deletePtrType = reflect.TypeOf(new(*Delete)).Elem()
-var dislikePtrType = reflect.TypeOf(new(*Dislike)).Elem()
-var flagPtrType = reflect.TypeOf(new(*Flag)).Elem()
-var followPtrType = reflect.TypeOf(new(*Follow)).Elem()
-var ignorePtrType = reflect.TypeOf(new(*Ignore)).Elem()
-var invitePtrType = reflect.TypeOf(new(*Invite)).Elem()
-var joinPtrType = reflect.TypeOf(new(*Join)).Elem()
-var leavePtrType = reflect.TypeOf(new(*Leave)).Elem()
-var likePtrType = reflect.TypeOf(new(*Like)).Elem()
-var listenPtrType = reflect.TypeOf(new(*Listen)).Elem()
-var movePtrType = reflect.TypeOf(new(*Move)).Elem()
-var offerPtrType = reflect.TypeOf(new(*Offer)).Elem()
-var questionPtrType = reflect.TypeOf(new(*Question)).Elem()
-var rejectPtrType = reflect.TypeOf(new(*Reject)).Elem()
-var readPtrType = reflect.TypeOf(new(*Read)).Elem()
-var removePtrType = reflect.TypeOf(new(*Remove)).Elem()
-var tentativeRejectPtrType = reflect.TypeOf(new(*TentativeReject)).Elem()
-var tentativeAcceptPtrType = reflect.TypeOf(new(*TentativeAccept)).Elem()
-var travelPtrType = reflect.TypeOf(new(*Travel)).Elem()
-var undoPtrType = reflect.TypeOf(new(*Undo)).Elem()
-var updatePtrType = reflect.TypeOf(new(*Update)).Elem()
-var viewPtrType = reflect.TypeOf(new(*View)).Elem()
+var (
+	objectPtrType                = reflect.TypeOf(new(*Object)).Elem()
+	tombstoneType                = reflect.TypeOf(new(*Tombstone)).Elem()
+	profileType                  = reflect.TypeOf(new(*Profile)).Elem()
+	placeType                    = reflect.TypeOf(new(*Place)).Elem()
+	relationshipType             = reflect.TypeOf(new(*Relationship)).Elem()
+	linkPtrType                  = reflect.TypeOf(new(*Link)).Elem()
+	mentionPtrType               = reflect.TypeOf(new(*Mention)).Elem()
+	activityPtrType              = reflect.TypeOf(new(*Activity)).Elem()
+	intransitiveActivityPtrType  = reflect.TypeOf(new(*IntransitiveActivity)).Elem()
+	collectionPtrType            = reflect.TypeOf(new(*Collection)).Elem()
+	collectionPagePtrType        = reflect.TypeOf(new(*CollectionPage)).Elem()
+	orderedCollectionPtrType     = reflect.TypeOf(new(*OrderedCollection)).Elem()
+	orderedCollectionPagePtrType = reflect.TypeOf(new(*OrderedCollectionPage)).Elem()
+	actorPtrType                 = reflect.TypeOf(new(*Actor)).Elem()
+	applicationPtrType           = reflect.TypeOf(new(*Application)).Elem()
+	servicePtrType               = reflect.TypeOf(new(*Service)).Elem()
+	personPtrType                = reflect.TypeOf(new(*Person)).Elem()
+	groupPtrType                 = reflect.TypeOf(new(*Group)).Elem()
+	organizationPtrType          = reflect.TypeOf(new(*Organization)).Elem()
+	acceptPtrType                = reflect.TypeOf(new(*Accept)).Elem()
+	addPtrType                   = reflect.TypeOf(new(*Add)).Elem()
+	announcePtrType              = reflect.TypeOf(new(*Announce)).Elem()
+	arrivePtrType                = reflect.TypeOf(new(*Arrive)).Elem()
+	blockPtrType                 = reflect.TypeOf(new(*Block)).Elem()
+	createPtrType                = reflect.TypeOf(new(*Create)).Elem()
+	deletePtrType                = reflect.TypeOf(new(*Delete)).Elem()
+	dislikePtrType               = reflect.TypeOf(new(*Dislike)).Elem()
+	flagPtrType                  = reflect.TypeOf(new(*Flag)).Elem()
+	followPtrType                = reflect.TypeOf(new(*Follow)).Elem()
+	ignorePtrType                = reflect.TypeOf(new(*Ignore)).Elem()
+	invitePtrType                = reflect.TypeOf(new(*Invite)).Elem()
+	joinPtrType                  = reflect.TypeOf(new(*Join)).Elem()
+	leavePtrType                 = reflect.TypeOf(new(*Leave)).Elem()
+	likePtrType                  = reflect.TypeOf(new(*Like)).Elem()
+	listenPtrType                = reflect.TypeOf(new(*Listen)).Elem()
+	movePtrType                  = reflect.TypeOf(new(*Move)).Elem()
+	offerPtrType                 = reflect.TypeOf(new(*Offer)).Elem()
+	questionPtrType              = reflect.TypeOf(new(*Question)).Elem()
+	rejectPtrType                = reflect.TypeOf(new(*Reject)).Elem()
+	readPtrType                  = reflect.TypeOf(new(*Read)).Elem()
+	removePtrType                = reflect.TypeOf(new(*Remove)).Elem()
+	tentativeRejectPtrType       = reflect.TypeOf(new(*TentativeReject)).Elem()
+	tentativeAcceptPtrType       = reflect.TypeOf(new(*TentativeAccept)).Elem()
+	travelPtrType                = reflect.TypeOf(new(*Travel)).Elem()
+	undoPtrType                  = reflect.TypeOf(new(*Undo)).Elem()
+	updatePtrType                = reflect.TypeOf(new(*Update)).Elem()
+	viewPtrType                  = reflect.TypeOf(new(*View)).Elem()
+)
 
 var tests = testPairs{
 	ObjectType:                objectPtrType,
@@ -411,7 +413,6 @@ func TestJSONGetDuration(t *testing.T) {
 }
 
 func TestJSONGetInt(t *testing.T) {
-
 }
 
 func TestJSONGetIRI(t *testing.T) {
@@ -423,7 +424,6 @@ func TestJSONGetItem(t *testing.T) {
 }
 
 func TestJSONGetItems(t *testing.T) {
-
 }
 
 func TestJSONGetLangRefField(t *testing.T) {

--- a/encoding_json.go
+++ b/encoding_json.go
@@ -64,7 +64,7 @@ func writeNaturalLanguageJSONProp(b *[]byte, n string, nl NaturalLanguageValues)
 	return false
 }
 
-func writeStringJSONProp(b *[]byte, n string, s string) (notEmpty bool) {
+func writeStringJSONProp(b *[]byte, n, s string) (notEmpty bool) {
 	return writeJSONProp(b, n, []byte(fmt.Sprintf(`"%s"`, s)))
 }
 

--- a/encoding_json.go
+++ b/encoding_json.go
@@ -5,7 +5,7 @@ import (
 	"fmt"
 	"time"
 
-	"git.sr.ht/~mariusor/go-xsd-duration"
+	xsd "git.sr.ht/~mariusor/go-xsd-duration"
 	"github.com/go-ap/jsonld"
 )
 

--- a/flatten.go
+++ b/flatten.go
@@ -19,7 +19,7 @@ func FlattenIntransitiveActivityProperties(act *IntransitiveActivity) *Intransit
 	act.Result = FlattenToIRI(act.Result)
 	act.Instrument = FlattenToIRI(act.Instrument)
 	OnObject(act, func(o *Object) error {
-		o = FlattenObjectProperties(o)
+		FlattenObjectProperties(o)
 		return nil
 	})
 	return act
@@ -61,7 +61,7 @@ func FlattenOrderedCollection(col *OrderedCollection) *OrderedCollection {
 // FlattenActorProperties flattens the Actor's properties from Object types to IRI
 func FlattenActorProperties(a *Actor) *Actor {
 	OnObject(a, func(o *Object) error {
-		o = FlattenObjectProperties(o)
+		FlattenObjectProperties(o)
 		return nil
 	})
 	return a
@@ -87,24 +87,24 @@ func FlattenProperties(it Item) Item {
 	typ := it.GetType()
 	if IntransitiveActivityTypes.Contains(typ) {
 		OnIntransitiveActivity(it, func(a *IntransitiveActivity) error {
-			a = FlattenIntransitiveActivityProperties(a)
+			FlattenIntransitiveActivityProperties(a)
 			return nil
 		})
 	} else if ActivityTypes.Contains(typ) {
 		OnActivity(it, func(a *Activity) error {
-			a = FlattenActivityProperties(a)
+			FlattenActivityProperties(a)
 			return nil
 		})
 	}
 	if ActorTypes.Contains(typ) {
 		OnActor(it, func(a *Actor) error {
-			a = FlattenActorProperties(a)
+			FlattenActorProperties(a)
 			return nil
 		})
 	}
 	if ObjectTypes.Contains(typ) {
 		OnObject(it, func(o *Object) error {
-			o = FlattenObjectProperties(o)
+			FlattenObjectProperties(o)
 			return nil
 		})
 	}

--- a/flatten.go
+++ b/flatten.go
@@ -78,7 +78,7 @@ func FlattenObjectProperties(o *Object) *Object {
 	o.CC = FlattenItemCollection(o.CC)
 	o.BCC = FlattenItemCollection(o.BCC)
 	o.Audience = FlattenItemCollection(o.Audience)
-	//o.Tag = FlattenItemCollection(o.Tag)
+	// o.Tag = FlattenItemCollection(o.Tag)
 	return o
 }
 

--- a/go.sum
+++ b/go.sum
@@ -1,6 +1,0 @@
-git.sr.ht/~mariusor/go-xsd-duration v0.0.0-20200411073322-f0bcc40f0bf2 h1:2OrsyJYZp7J6nyAsKi2q1SELYRaIc0aQmcQ/EQqPfk8=
-git.sr.ht/~mariusor/go-xsd-duration v0.0.0-20200411073322-f0bcc40f0bf2/go.mod h1:g/V2Hjas6Z1UHUp4yIx6bATpNzJ7DYtD0FG3+xARWxs=
-github.com/go-ap/jsonld v0.0.0-20200327122108-fafac2de2660 h1:AUG8+r0Q/zbNUAi5CWVBK5oUhOZDX3Kkr+oWURaJIfU=
-github.com/go-ap/jsonld v0.0.0-20200327122108-fafac2de2660/go.mod h1:jyveZeGw5LaADntW+UEsMjl3IlIwk+DxlYNsbofQkGA=
-github.com/valyala/fastjson v1.6.3 h1:tAKFnnwmeMGPbwJ7IwxcTPCNr3uIzoIj3/Fh90ra4xc=
-github.com/valyala/fastjson v1.6.3/go.mod h1:CLCAqky6SMuOcxStkYQvblddUtoRxhYMGLrsQns1aXY=

--- a/go.sum
+++ b/go.sum
@@ -1,0 +1,6 @@
+git.sr.ht/~mariusor/go-xsd-duration v0.0.0-20200411073322-f0bcc40f0bf2 h1:2OrsyJYZp7J6nyAsKi2q1SELYRaIc0aQmcQ/EQqPfk8=
+git.sr.ht/~mariusor/go-xsd-duration v0.0.0-20200411073322-f0bcc40f0bf2/go.mod h1:g/V2Hjas6Z1UHUp4yIx6bATpNzJ7DYtD0FG3+xARWxs=
+github.com/go-ap/jsonld v0.0.0-20200327122108-fafac2de2660 h1:AUG8+r0Q/zbNUAi5CWVBK5oUhOZDX3Kkr+oWURaJIfU=
+github.com/go-ap/jsonld v0.0.0-20200327122108-fafac2de2660/go.mod h1:jyveZeGw5LaADntW+UEsMjl3IlIwk+DxlYNsbofQkGA=
+github.com/valyala/fastjson v1.6.3 h1:tAKFnnwmeMGPbwJ7IwxcTPCNr3uIzoIj3/Fh90ra4xc=
+github.com/valyala/fastjson v1.6.3/go.mod h1:CLCAqky6SMuOcxStkYQvblddUtoRxhYMGLrsQns1aXY=

--- a/intransitive_activity.go
+++ b/intransitive_activity.go
@@ -216,7 +216,7 @@ func (i IntransitiveActivity) MarshalBinary() ([]byte, error) {
 }
 
 func (i IntransitiveActivity) GobEncode() ([]byte, error) {
-	var mm = make(map[string][]byte)
+	mm := make(map[string][]byte)
 	hasData, err := mapIntransitiveActivityProperties(mm, &i)
 	if err != nil {
 		return nil, err

--- a/intransitive_activity_test.go
+++ b/intransitive_activity_test.go
@@ -3,7 +3,7 @@ package activitypub
 import "testing"
 
 func TestIntransitiveActivityNew(t *testing.T) {
-	var testValue = ID("test")
+	testValue := ID("test")
 	var testType ActivityVocabularyType = "Arrive"
 
 	a := IntransitiveActivityNew(testValue, testType)
@@ -105,6 +105,7 @@ func TestIntransitiveActivityRecipients(t *testing.T) {
 		t.Error(err)
 	}
 }
+
 func TestIntransitiveActivity_GetLink(t *testing.T) {
 	i := IntransitiveActivityNew("test", QuestionType)
 
@@ -112,6 +113,7 @@ func TestIntransitiveActivity_GetLink(t *testing.T) {
 		t.Errorf("%T should return an empty %T object. Received %#v", i, i, i)
 	}
 }
+
 func TestIntransitiveActivity_GetObject(t *testing.T) {
 	i := IntransitiveActivityNew("test", QuestionType)
 
@@ -119,6 +121,7 @@ func TestIntransitiveActivity_GetObject(t *testing.T) {
 		t.Errorf("%T should not return an empty %T object. Received %#v", i, i, i)
 	}
 }
+
 func TestIntransitiveActivity_IsLink(t *testing.T) {
 	i := IntransitiveActivityNew("test", QuestionType)
 
@@ -126,6 +129,7 @@ func TestIntransitiveActivity_IsLink(t *testing.T) {
 		t.Errorf("%T should not respond true to IsLink", i)
 	}
 }
+
 func TestIntransitiveActivity_IsObject(t *testing.T) {
 	i := IntransitiveActivityNew("test", ActivityType)
 
@@ -133,6 +137,7 @@ func TestIntransitiveActivity_IsObject(t *testing.T) {
 		t.Errorf("%T should respond true to IsObject", i)
 	}
 }
+
 func TestIntransitiveActivity_Recipients(t *testing.T) {
 	to := PersonNew("bob")
 	o := ObjectNew(ArticleType)
@@ -234,7 +239,7 @@ func TestIntransitiveActivity_UnmarshalJSON(t *testing.T) {
 }
 
 func TestArriveNew(t *testing.T) {
-	var testValue = ID("test")
+	testValue := ID("test")
 
 	a := ArriveNew(testValue)
 
@@ -247,7 +252,7 @@ func TestArriveNew(t *testing.T) {
 }
 
 func TestTravelNew(t *testing.T) {
-	var testValue = ID("test")
+	testValue := ID("test")
 
 	a := TravelNew(testValue)
 

--- a/iri.go
+++ b/iri.go
@@ -230,14 +230,14 @@ func (i IRI) Equals(with IRI, checkScheme bool) bool {
 	u, e := i.URL()
 	uw, ew := with.URL()
 	if e != nil || ew != nil || !validURL(u) || !validURL(uw) {
-		return strings.ToLower(i.String()) == strings.ToLower(with.String())
+		return strings.EqualFold(i.String(), with.String())
 	}
 	if checkScheme {
-		if strings.ToLower(u.Scheme) != strings.ToLower(uw.Scheme) {
+		if !strings.EqualFold(u.Scheme, uw.Scheme) {
 			return false
 		}
 	}
-	if strings.ToLower(u.Host) != strings.ToLower(uw.Host) {
+	if !strings.EqualFold(u.Host, uw.Host) {
 		return false
 	}
 	if path.Clean(u.Path) != path.Clean(uw.Path) {

--- a/iri_test.go
+++ b/iri_test.go
@@ -53,8 +53,7 @@ func TestIRI_IsObject(t *testing.T) {
 	if ii.IsObject() {
 		t.Errorf("%T.IsObject() returned %t, expected %t", ii, ii.IsObject(), false)
 	}
-	var iii *IRI
-	iii = &ii
+	iii := &ii
 	if iii.IsObject() {
 		t.Errorf("%T.IsObject() returned %t, expected %t", iii, iii.IsObject(), false)
 	}

--- a/link.go
+++ b/link.go
@@ -3,7 +3,7 @@ package activitypub
 import (
 	"bytes"
 	"encoding/gob"
-  "fmt"
+ 	"fmt"
 	"io"
 
 	"github.com/valyala/fastjson"

--- a/link.go
+++ b/link.go
@@ -3,6 +3,7 @@ package activitypub
 import (
 	"bytes"
 	"encoding/gob"
+
 	"github.com/valyala/fastjson"
 )
 

--- a/link.go
+++ b/link.go
@@ -3,7 +3,7 @@ package activitypub
 import (
 	"bytes"
 	"encoding/gob"
- 	"fmt"
+	"fmt"
 	"io"
 
 	"github.com/valyala/fastjson"

--- a/link_test.go
+++ b/link_test.go
@@ -6,7 +6,7 @@ import (
 )
 
 func TestLinkNew(t *testing.T) {
-	var testValue = ID("test")
+	testValue := ID("test")
 	var testType ActivityVocabularyType
 
 	l := LinkNew(testValue, testType)

--- a/natural_language_values.go
+++ b/natural_language_values.go
@@ -137,15 +137,7 @@ func (n NaturalLanguageValues) MarshalText() ([]byte, error) {
 // Append is syntactic sugar for resizing the NaturalLanguageValues map
 // and appending an element
 func (n *NaturalLanguageValues) Append(lang LangRef, value Content) error {
-	var t NaturalLanguageValues
-	if len(*n) == 0 {
-		t = make(NaturalLanguageValues, 0)
-	} else {
-		t = *n
-	}
-	t = append(*n, LangRefValue{lang, value})
-	*n = t
-
+	*n = append(*n, LangRefValue{lang, value})
 	return nil
 }
 

--- a/natural_language_values_test.go
+++ b/natural_language_values_test.go
@@ -22,7 +22,6 @@ func TestNaturalLanguageValue_MarshalJSON(t *testing.T) {
 	}
 	js := "{\"en\":\"the test\",\"fr\":\"le test\"}"
 	out, err := p.MarshalJSON()
-
 	if err != nil {
 		t.Errorf("Error: '%s'", err)
 	}
@@ -188,9 +187,9 @@ func TestNaturalLanguageValue_UnmarshalFullObjectJSON(t *testing.T) {
 	langDe := "de-DE"
 	valDe := Content("zufällig\n")
 
-	//m := make(map[string]string)
-	//m[langEn] = valEn
-	//m[langDe] = valDe
+	// m := make(map[string]string)
+	// m[langEn] = valEn
+	// m[langDe] = valDe
 
 	json := `{
 		"` + langEn + `": "` + valEn.String() + `",
@@ -299,8 +298,8 @@ func TestNaturalLanguageValues_MarshalJSON(t *testing.T) {
 		if string(result) != mRes {
 			t.Errorf("Different results '%v' vs. '%v'", string(result), mRes)
 		}
-		//n := NaturalLanguageValuesNew()
-		//result, err := n.MarshalJSON()
+		// n := NaturalLanguageValuesNew()
+		// result, err := n.MarshalJSON()
 
 		s := make(map[LangRef]string)
 		s["en"] = "test"

--- a/object_test.go
+++ b/object_test.go
@@ -9,8 +9,8 @@ import (
 )
 
 func TestObjectNew(t *testing.T) {
-	var testValue = ID("test")
-	var testType = ArticleType
+	testValue := ID("test")
+	testType := ArticleType
 
 	o := ObjectNew(testType)
 	o.ID = testValue
@@ -30,7 +30,6 @@ func TestObjectNew(t *testing.T) {
 	if n.Type != ObjectType {
 		t.Errorf("APObject Type '%v' different than expected '%v'", n.Type, ObjectType)
 	}
-
 }
 
 func TestActivityVocabularyTypes_Contains(t *testing.T) {

--- a/ordered_collection.go
+++ b/ordered_collection.go
@@ -280,7 +280,7 @@ func (o OrderedCollection) MarshalBinary() ([]byte, error) {
 
 // GobEncode
 func (o OrderedCollection) GobEncode() ([]byte, error) {
-	var mm = make(map[string][]byte)
+	mm := make(map[string][]byte)
 	hasData, err := mapOrderedCollectionProperties(mm, o)
 	if err != nil {
 		return nil, err

--- a/ordered_collection_page.go
+++ b/ordered_collection_page.go
@@ -251,7 +251,7 @@ func (o OrderedCollectionPage) MarshalBinary() ([]byte, error) {
 
 // GobEncode
 func (o OrderedCollectionPage) GobEncode() ([]byte, error) {
-	var mm = make(map[string][]byte)
+	mm := make(map[string][]byte)
 	hasData, err := mapOrderedCollectionPageProperties(mm, o)
 	if err != nil {
 		return nil, err

--- a/ordered_collection_page_test.go
+++ b/ordered_collection_page_test.go
@@ -7,7 +7,7 @@ import (
 )
 
 func TestOrderedCollectionPageNew(t *testing.T) {
-	var testValue = ID("test")
+	testValue := ID("test")
 
 	c := OrderedCollectionNew(testValue)
 	p := OrderedCollectionPageNew(c)

--- a/ordered_collection_test.go
+++ b/ordered_collection_test.go
@@ -7,7 +7,7 @@ import (
 )
 
 func TestOrderedCollectionNew(t *testing.T) {
-	var testValue = ID("test")
+	testValue := ID("test")
 
 	c := OrderedCollectionNew(testValue)
 

--- a/question_test.go
+++ b/question_test.go
@@ -3,7 +3,7 @@ package activitypub
 import "testing"
 
 func TestQuestionNew(t *testing.T) {
-	var testValue = ID("test")
+	testValue := ID("test")
 
 	a := QuestionNew(testValue)
 

--- a/tests/integration_test.go
+++ b/tests/integration_test.go
@@ -1,12 +1,12 @@
 package tests
 
 import (
+	"strings"
 	"testing"
 
 	j "github.com/go-ap/jsonld"
 
 	pub "github.com/go-ap/activitypub"
-	"strings"
 )
 
 func TestAcceptSerialization(t *testing.T) {

--- a/tests/server_common_test.go
+++ b/tests/server_common_test.go
@@ -6,7 +6,7 @@ import (
 	"testing"
 )
 
-//Server: Fetching the inbox
+// Server: Fetching the inbox
 // Try retrieving the actor's inbox of an actor.
 // Server responds to GET request at inbox URL
 func TestInboxGETRequest(t *testing.T) {
@@ -19,7 +19,7 @@ Server: Fetching the inbox
 	t.Skip(desc)
 }
 
-//Server: Fetching the inbox
+// Server: Fetching the inbox
 // Try retrieving the actor's inbox of an actor.
 // inbox is an OrderedCollection
 func TestInboxIsOrderedCollection(t *testing.T) {
@@ -32,7 +32,7 @@ Server: Fetching the inbox
 	t.Skip(desc)
 }
 
-//Server: Fetching the inbox
+// Server: Fetching the inbox
 // Try retrieving the actor's inbox of an actor.
 // Server filters inbox content according to the requester's permission
 func TestInboxFilteringBasedOnPermissions(t *testing.T) {

--- a/tests/server_to_server_test.go
+++ b/tests/server_to_server_test.go
@@ -4,8 +4,9 @@ package tests
 
 import (
 	"fmt"
-	pub "github.com/go-ap/activitypub"
 	"testing"
+
+	pub "github.com/go-ap/activitypub"
 )
 
 // S2S Server: Activities requiring the object property
@@ -431,7 +432,7 @@ S2S Server: Delete activity
 	t.Skip(desc)
 }
 
-//S2S Server: Following, and handling accept/reject of follows
+// S2S Server: Following, and handling accept/reject of follows
 // Follow should add the activity's actor to the receiving actor's Followers Collection.
 func TestFollowAddsToFollowers(t *testing.T) {
 	desc := `
@@ -442,7 +443,7 @@ S2S Server: Following, and handling accept/reject of follows
 	t.Skip(desc)
 }
 
-//S2S Server: Following, and handling accept/reject of follows
+// S2S Server: Following, and handling accept/reject of follows
 // Generates either an Accept or Reject activity with Follow as object and deliver to actor of the Follow
 func TestGeneratesAcceptOrReject(t *testing.T) {
 	desc := `
@@ -453,7 +454,7 @@ S2S Server: Following, and handling accept/reject of follows
 	t.Skip(desc)
 }
 
-//S2S Server: Following, and handling accept/reject of follows
+// S2S Server: Following, and handling accept/reject of follows
 // If receiving an Accept in reply to a Follow activity, adds actor to receiver's Following Collection
 func TestAddsFollowerIfAccept(t *testing.T) {
 	desc := `
@@ -464,7 +465,7 @@ S2S Server: Following, and handling accept/reject of follows
 	t.Skip(desc)
 }
 
-//S2S Server: Following, and handling accept/reject of follows
+// S2S Server: Following, and handling accept/reject of follows
 // If receiving a Reject in reply to a Follow activity, does not add actor to receiver's Following Collection
 func TestDoesntAddFollowerIfReject(t *testing.T) {
 	desc := `

--- a/tests/unmarshal_test.go
+++ b/tests/unmarshal_test.go
@@ -3,7 +3,6 @@ package tests
 import (
 	"bytes"
 	"fmt"
-	pub "github.com/go-ap/activitypub"
 	"io"
 	"os"
 	"path/filepath"
@@ -11,6 +10,8 @@ import (
 	"testing"
 	"time"
 	"unsafe"
+
+	pub "github.com/go-ap/activitypub"
 
 	j "github.com/go-ap/jsonld"
 )
@@ -395,8 +396,8 @@ var allTests = testMaps{
 				&pub.Object{
 					ID:           pub.ID("http://example.com/outbox/53c6fb47"),
 					Type:         pub.ArticleType,
-					Name:         pub.NaturalLanguageValues{{pub.NilLangRef, pub.Content("Example title")}},
-					Content:      pub.NaturalLanguageValues{{pub.NilLangRef, pub.Content("Example content!")}},
+					Name:         pub.NaturalLanguageValues{{Ref: pub.NilLangRef, Value: pub.Content("Example title")}},
+					Content:      pub.NaturalLanguageValues{{Ref: pub.NilLangRef, Value: pub.Content("Example content!")}},
 					URL:          pub.IRI("http://example.com/53c6fb47"),
 					MediaType:    pub.MimeType("text/markdown"),
 					Published:    time.Date(2018, time.July, 5, 16, 46, 44, 0, zLoc),
@@ -526,7 +527,7 @@ func getFileContents(path string) ([]byte, error) {
 func TestUnmarshal(t *testing.T) {
 	var err error
 
-	var f = t.Errorf
+	f := t.Errorf
 	if len(allTests) == 0 {
 		t.Skip("No tests found")
 	}

--- a/tombstone_test.go
+++ b/tombstone_test.go
@@ -36,6 +36,7 @@ func TestTombstone_UnmarshalJSON(t *testing.T) {
 func TestTombstone_Clean(t *testing.T) {
 	t.Skipf("TODO")
 }
+
 func assertTombstoneWithTesting(fn canErrorFunc, expected *Tombstone) withTombstoneFn {
 	return func(p *Tombstone) error {
 		if !assertDeepEquals(fn, p, expected) {

--- a/validation.go
+++ b/validation.go
@@ -14,9 +14,3 @@ type ValidationErrors interface {
 type Validator interface {
 	Validate(receiver IRI, incoming Item) (bool, ValidationErrors)
 }
-
-func (v defaultValidator) Validate(receiver IRI, incoming Item) (bool, ValidationErrors) {
-	return true, nil
-}
-
-type defaultValidator struct{}


### PR DESCRIPTION
- Running the [golangci-lint](https://github.com/golangci/golangci-lint/) over the code detected some errors. Unfortunately there are still some more errors(mostly error-checking + unused code in test files), so it cannot be enabled _yet_.
- Add go.sum
- Use [`strings.EqualFold`](https://pkg.go.dev/strings#EqualFold) instead of doing `strings.ToLower` twice, which is also a more correct-form to do case inequality checking.
-  Remove some dead-code that isn't exported and not used by the current code.
- Fixed a error that prevented the compiler to compile the code.
- Remove ineffective assignments(you already pass a pointer, so no need to assign the same pointer to the pointer).
- And run [gofumpt](https://github.com/mvdan/gofumpt) over the code to do some automatic code styling.